### PR TITLE
fix: make get asset not throw if undefined

### DIFF
--- a/packages/asset-manager/package.json
+++ b/packages/asset-manager/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@nanoforge-dev/asset-manager",
-  "version": "1.3.1",
+  "version": "1.3.2-alpha.make-get-asset-not-throw-if-undefined.0",
   "description": "NanoForge Engine - Asset Manager",
   "keywords": [
     "nanoforge",

--- a/packages/asset-manager/src/asset-manager.library.ts
+++ b/packages/asset-manager/src/asset-manager.library.ts
@@ -43,12 +43,17 @@ export class AssetManagerLibrary extends BaseAssetManagerLibrary {
    * collapsed and trailing slashes are removed.
    *
    * @param path - Virtual path of the asset (e.g. "/textures/hero.png").
-   * @returns An `NfFile` handle for the requested asset.
+   * @returns An `NfFile` handle for the requested asset, or `undefined` if no asset path is provided.
    * @throws `NfNotFound` When no asset is registered at the given path.
    * @throws `NfNotInitializedException` When called before `__init` has resolved.
    */
-  public getAsset(path: string): NfFile {
+  public getAsset(path: string): NfFile;
+  public getAsset(path: "" | undefined): undefined;
+  public getAsset(path: string | undefined): NfFile | undefined {
     if (!this._assets) this.throwNotInitializedError();
+
+    if (!path) return undefined;
+
     const res = this._assets.get(this._parsePath(path));
     if (!res) throw new NfNotFound(path, "Asset");
     return new NfFile(res);

--- a/packages/asset-manager/test/asset-manager.library.spec.ts
+++ b/packages/asset-manager/test/asset-manager.library.spec.ts
@@ -75,5 +75,10 @@ describe("AssetManagerLibrary", () => {
     it("should throw NfNotFound for an unknown wgsl", () => {
       expect(() => library.getAsset("unknown.wgsl")).toThrow(NfNotFound);
     });
+
+    it("should return undefined for an undefined path", () => {
+      expect(library.getAsset(undefined)).toBe(undefined);
+      expect(library.getAsset("")).toBe(undefined);
+    });
   });
 });

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://json.schemastore.org/package.json",
   "name": "@nanoforge-dev/common",
-  "version": "1.3.1",
+  "version": "1.3.2-alpha.make-get-asset-not-throw-if-undefined.0",
   "description": "NanoForge Engine - Common",
   "keywords": [
     "nanoforge",

--- a/packages/common/src/library/libraries/abstracts/asset-manager.library.abstract.ts
+++ b/packages/common/src/library/libraries/abstracts/asset-manager.library.abstract.ts
@@ -24,4 +24,5 @@ export abstract class BaseAssetManagerLibrary extends Library implements IAssetM
    * @throws `NfNotInitializedException` When called before `__init` has resolved.
    */
   public abstract getAsset(path: string): NfFile;
+  public abstract getAsset(path: "" | undefined): undefined;
 }

--- a/packages/common/src/library/libraries/interfaces/finals/asset-manager.library.type.ts
+++ b/packages/common/src/library/libraries/interfaces/finals/asset-manager.library.type.ts
@@ -14,8 +14,9 @@ export interface IAssetManagerLibrary extends IExposedLibrary {
    * Retrieve a registered file asset by its virtual path.
    *
    * @param path - Virtual path of the asset (e.g. "/textures/hero.png").
-   * @returns An `NfFile` handle for the requested asset.
+   * @returns An `NfFile` handle for the requested asset, or `undefined` if no asset path is provided.
    * @throws `NfNotFound` When no asset is registered at the given path.
    */
   getAsset(path: string): NfFile;
+  getAsset(path: "" | undefined): undefined;
 }


### PR DESCRIPTION
## What does this PR do?

Currently, if the path is an empty string or undefined, the getAsset function throws. It may cause problems in the generation when trying to getAsset from an undefined param.

This pr makes the getAsset function return undefined if the path pass in params is undefined or empty string.

## How do you test this PR?
