### PR TITLE
fix: change check for address from fqdn to url

### DIFF
--- a/packages/common/src/library/config/interfaces/config-registry.type.ts
+++ b/packages/common/src/library/config/interfaces/config-registry.type.ts
@@ -5,7 +5,7 @@
  * @remarks
  * An instance is available in `InitContext.config`.  Configuration
  * classes must be decorated with `class-transformer` (`@Expose`, `@Default`)
- * and `class-validator` (`@IsPort`, `@IsIpOrFQDN`, etc.) decorators from
+ * and `class-validator` (`@IsPort`, `@IsIpOrURL`, etc.) decorators from
  * `@nanoforge-dev/config`.
  *
  * @example

--- a/packages/config/README.md
+++ b/packages/config/README.md
@@ -101,7 +101,7 @@ import {
   Default,
   Expose,
   IsByteLength,
-  IsIpOrFQDN,
+  IsIpOrURL,
   IsOptional,
   IsPort,
 } from "@nanoforge-dev/config";
@@ -120,7 +120,7 @@ export class ClientConfigNetwork {
 
   // This var must be ip address or fqdn (it cannot be undefined)
   @Expose()
-  @IsIpOrFQDN()
+  @IsIpOrURL()
   SERVER_ADDRESS?: string;
 
   // This var must be a byte length between 2 and 64. It can be undefined as it as a default value.

--- a/packages/config/src/validators/index.ts
+++ b/packages/config/src/validators/index.ts
@@ -1,1 +1,1 @@
-export { IsIpOrFQDN } from "./is-ip-or-fqdn.validator";
+export { IsIpOrURL } from "./is-ip-or-url.validator";

--- a/packages/config/src/validators/is-ip-or-url.validator.ts
+++ b/packages/config/src/validators/is-ip-or-url.validator.ts
@@ -1,11 +1,11 @@
-import { type ValidationOptions, isFQDN, isIP, registerDecorator } from "class-validator";
+import { type ValidationOptions, isIP, isURL, registerDecorator } from "class-validator";
 
 /**
  * Property decorator that validates whether the value is a valid IPv4/IPv6
- * address or a fully qualified domain name (FQDN).
+ * address or a fully qualified domain name (URL).
  *
  * @remarks
- * Built on top of `class-validator`'s `isIP` and `isFQDN` helpers.  Use on
+ * Built on top of `class-validator`'s `isIP` and `isURL` helpers.  Use on
  * config properties that represent server hostnames or addresses.
  *
  * @param validationOptions - Optional class-validator validation options.
@@ -14,12 +14,12 @@ import { type ValidationOptions, isFQDN, isIP, registerDecorator } from "class-v
  * ```ts
  * class MyConfig {
  *   \@Expose()
- *   \@IsIpOrFQDN()
+ *   \@IsIpOrURL()
  *   SERVER_ADDRESS!: string;
  * }
  * ```
  */
-export const IsIpOrFQDN = (validationOptions?: ValidationOptions) => {
+export const IsIpOrURL = (validationOptions?: ValidationOptions) => {
   return (object: object, propertyName: string) => {
     registerDecorator({
       target: object.constructor,
@@ -28,10 +28,10 @@ export const IsIpOrFQDN = (validationOptions?: ValidationOptions) => {
       constraints: [],
       validator: {
         validate(value: string) {
-          return isIP(value) || isFQDN(value);
+          return isIP(value) || isURL(value);
         },
         defaultMessage() {
-          return `$value must be a valid IP address or FQDN`;
+          return `$value must be a valid IP address or URL`;
         },
       },
     });

--- a/packages/network-client/src/config.client.network.ts
+++ b/packages/network-client/src/config.client.network.ts
@@ -3,7 +3,7 @@ import {
   Expose,
   IsBoolean,
   IsByteLength,
-  IsIpOrFQDN,
+  IsIpOrURL,
   IsOptional,
   IsPort,
   TransformToBoolean,
@@ -42,7 +42,7 @@ export class ClientConfigNetwork {
 
   /** Hostname or IP address of the game server. */
   @Expose()
-  @IsIpOrFQDN()
+  @IsIpOrURL()
   SERVER_ADDRESS!: string;
 
   /**

--- a/packages/network-server/src/config.server.network.ts
+++ b/packages/network-server/src/config.server.network.ts
@@ -2,7 +2,7 @@ import {
   Default,
   Expose,
   IsByteLength,
-  IsIpOrFQDN,
+  IsIpOrURL,
   IsOptional,
   IsPort,
   IsString,
@@ -46,7 +46,7 @@ export class ServerConfigNetwork {
    */
   @Expose()
   @Default("0.0.0.0")
-  @IsIpOrFQDN()
+  @IsIpOrURL()
   LISTENING_INTERFACE!: string;
 
   /**


### PR DESCRIPTION
## What does this PR do?

The current behavior makes this kind of SERVER_ADDRESS doesn't work:
`wss://ws-demo-demo-games.nanoforge.eu`
This pr fix that

## How do you test this PR?
